### PR TITLE
Fix aerospike-client version to 3.3.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
 		<dependency>
 			<groupId>com.aerospike</groupId>
 			<artifactId>aerospike-client</artifactId>
-			<version>[3.1.3,)</version>
+			<version>3.3.4</version>
 		</dependency>
 		<!-- Apache command line parser. -->
 		<dependency>


### PR DESCRIPTION
Should be 3.3.1< and <4.
v3.3.4 is the last version in 3.3 series.